### PR TITLE
Move requires around to get tests running.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require "capybara/rails"
 require "capybara/rspec"
 require "simplecov"
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -15,5 +15,4 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
   config.order = :random
-  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "capybara/rails"

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "factory_bot_rails"


### PR DESCRIPTION
## What did we change?

- Require Rails-specific libraries from the Rails helper.
- Removed a duplicate FactoryBot include.

## Why are we doing this?

I couldn't run the tests locally without this.