### PR TITLE
Post build notifications to #pb-a-ezhackathon

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -3,6 +3,8 @@
 
 name: ezhackathon
 skip_production_deploy: false
+slack:
+  default: pb-a-ezhackathon
 pipeline:
   sandbox_cd_branch: main
 experimental:


### PR DESCRIPTION
## What did we change?

Ensured that Skyline posts all build notifications for `main` this project to the `#pb-a-ezhackathon` Slack channel

## Why are we doing this?

So we see if builds fail and also when new features are released

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
