### PR TITLE
Drop columns on Project that exist on Idea

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
 class Project < ApplicationRecord
-  # delegated to idea
-  self.ignored_columns = %w(
-    name
-    tagline
-    description
-    resources
-    snowflake_access
-    value_delivered
-    goal
-    hours_estimate
-  )
-
   belongs_to :event
   belongs_to :idea
 end

--- a/db/migrate/20210929151726_drop_project_columns_duplicated_in_idea.rb
+++ b/db/migrate/20210929151726_drop_project_columns_duplicated_in_idea.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DropProjectColumnsDuplicatedInIdea < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :projects, :name, :string, null: false
+      remove_column :projects, :tagline, :string, null: false, length: 500
+      remove_column :projects, :description, :string, null: false
+      remove_column :projects, :resources, :string, null: false
+      remove_column :projects, :snowflake_access, :boolean
+      remove_column :projects, :value_delivered, :string, null: false
+      remove_column :projects, :goal, :string, null: false
+      remove_column :projects, :hours_estimate, :integer, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,6 +11,8 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
+SET default_table_access_method = heap;
+
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
@@ -137,14 +139,6 @@ ALTER SEQUENCE public.ideas_id_seq OWNED BY public.ideas.id;
 
 CREATE TABLE public.projects (
     id bigint NOT NULL,
-    name character varying NOT NULL,
-    tagline character varying NOT NULL,
-    description text NOT NULL,
-    resources character varying NOT NULL,
-    snowflake_access boolean,
-    value_delivered character varying NOT NULL,
-    goal character varying NOT NULL,
-    hours_estimate integer NOT NULL,
     additional_comments character varying,
     links character varying,
     event_id bigint NOT NULL,
@@ -294,6 +288,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210929143110'),
 ('20210929143905'),
 ('20210929144014'),
-('20210929145743');
+('20210929145743'),
+('20210929151726');
 
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-# FactoryBot.define do
-#     factory :event do
-#       sequence(:start_time) { |n| DateTime.new(n) }
-#       end_time { DateTime.now }
-#       place { "Virtual" }
-#       agenda { "10am hacking"}
-#       organizers { "Rachael" }
-#     end
-#   end
+FactoryBot.define do
+  factory :event do
+    time { DateTime.now }
+    place { "Virtual" }
+    agenda { "10am hacking" }
+    participants { "Rachael" }
+    demo_links { "" }
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# FactoryBot.define do
-#   factory :project do
-#     association :idea
-#     # association :event  - event factory needs fixed. It doesn't match the model
-#   end
-# end
+FactoryBot.define do
+  factory :project do
+    association :idea
+    association :event
+  end
+end


### PR DESCRIPTION
## What did we change?

* Drop ignored columns
* Fix factories

## Why are we doing this?

So we can unblock work on `Projects` without them duplicating all the columns on `Item`

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
