### PR TITLE
Enable creating and editing projects based on ideas

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -44,7 +44,7 @@ body {
     background-color: white;
     border-radius: 8px;
     padding: 2%
- } 
+ }
 
  .projects {
     border-style: solid;
@@ -85,6 +85,10 @@ body {
     background-color: white;
     border-radius: 8px;
     padding: 2%
+ }
+
+ .full-width {
+    width: 100%
  }
 
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -39,13 +39,8 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
-    @time = format_time(@event)
     @projects = @event.projects
     render :show
-  end
-
-  def format_time(event)
-    event.time.strftime("%A %B %d, %Y")
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -40,9 +40,6 @@ class ProjectsController < ApplicationController
   private
 
   def project_params
-    params.require(:project).permit(:name, :tagline, :description, :resources, :snowflake_access,
-                                    :value_delivered, :goal, :hours_estimate, :additional_comments, :links)
-
-    # project name, team name, participants, confluence link, description
+    params.require(:project).permit(:idea_id, :additional_comments, :links)
   end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DateHelper
+  def format_date(date_or_time)
+    date_or_time.strftime("%A %B %d, %Y")
+  end
+end

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ProjectHelper
+  def available_ideas_for(project)
+    ideas = Idea.without_projects.order(:name)
+    project.idea.nil? ? ideas : [project.idea, *ideas]
+  end
+end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -5,7 +5,7 @@ class Idea < ApplicationRecord
   validates :tagline, presence: true, length: { maximum: 500 }
   validates :submitter, :description, :resources, :value_delivered, :goal, :hours_estimate, presence: true
 
-  scope :without_projects, ->{
+  scope :without_projects, lambda {
     joins("LEFT JOIN projects ON ideas.id = projects.idea_id").
       where(projects: { id: nil })
   }

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -4,4 +4,9 @@ class Idea < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :tagline, presence: true, length: { maximum: 500 }
   validates :submitter, :description, :resources, :value_delivered, :goal, :hours_estimate, presence: true
+
+  scope :without_projects, ->{
+    joins("LEFT JOIN projects ON ideas.id = projects.idea_id").
+      where(projects: { id: nil })
+  }
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,6 @@
 <p><%= link_to "Back to Events", events_path %></p>
-<h1> <%=@time%> </h1>
-<h3> <%=@event.place%> </h3>
+<h1> <%= format_date(@event.time) %> </h1>
+<h3> <%= @event.place%> </h3>
 
 <h4>Agenda:</h4>
 <pre><%= @event.agenda%></pre>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,11 +23,11 @@
       <div class="tagline">
         <%=project.idea.description%>
       </div>
-      <%= link_to "Edit Project", edit_event_project_path(@event), :method => "get" %>
+      <%= link_to "Edit Project", edit_event_project_path(@event, project), :method => "get" %>
     </div>
   <% end %>
 
-  <%=button_to "Add a New Project", new_event_project_path(@event), :method => "get", class:"button" %>
+  <%= button_to "Add a New Project", new_event_project_path(@event), :method => "get", class:"button" %>
 </div>
 
   <%= button_to "Edit Event", edit_event_path, :method => "get", class:"button" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,9 +19,9 @@
 
   <% @projects.each do |project|%>
     <div class="project">
-      <a href=<%=project.links%>><%="#{project.name}: #{project.tagline}"%></a>
+      <a href=<%=project.links%>><%="#{project.idea.name}: #{project.idea.tagline}"%></a>
       <div class="tagline">
-        <%=project.description%>
+        <%=project.idea.description%>
       </div>
       <%= link_to "Edit Project", edit_event_project_path(@event), :method => "get" %>
     </div>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,46 +1,18 @@
 <%= form_for [@event, @project] do |f| %>
     <div class="field">
-        What is the name of this project?<br />
-        <%= f.text_field :name %>
+        <%= f.label "Which idea is project based on?" %><br />
+        <%= f.collection_select(
+            :idea_id,
+            available_ideas_for(@project),
+            :id,
+            :name,
+            { prompt: "Please select the idea this project will work on", include_blank: true },
+            { class: "full-width", required: true }
+        ) %>
     </div>
 
     <div class="field">
-        <%= f.label :tagline %><br />
-        <%= f.text_field :tagline %>
-    </div>
-
-    <div class="field">
-        Describe your project:<br />
-        <%= f.text_field :description %>
-    </div>
-
-    <div class="field">
-        What resources do you need to be successful? (a skillset, person, access to a technology etc)<br />
-        <%= f.text_field :resources %>
-    </div>
-
-    <div class="field">
-        <%= f.label "This idea will need access to Snowflake (data):" %> <br />
-        <%= f.check_box :snowflake_access %> <br />
-    </div>
-
-    <div class="field">
-        What value will this project deliver?<br />
-        <%= f.text_field :value_delivered %>
-    </div>
-
-    <div class="field">
-        What is your goal for this project in the hackathon?<br />
-        <%= f.text_field :goal %>
-    </div>
-
-    <div class="field">
-        How many "people hours" do you estimate it will take to plan, scope and demo?<br />
-        <%= f.text_field :hours_estimate %>
-    </div>
-
-    <div class="field">
-        <%= f.label :links %><br />
+        <%= f.label "Add any links to your final artifacts" %><br />
         <%= f.text_field :links %>
     </div>
 
@@ -49,9 +21,7 @@
         <%= f.text_field :additional_comments %>
     </div>
 
-
-
     <div class="actions">
-    <%= f.submit class: "button" %>
+        <%= f.submit class: "button" %>
     </div>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -13,7 +13,7 @@
 
     <div class="field">
         <%= f.label "Add any links to your final artifacts" %><br />
-        <%= f.text_field :links %>
+        <%= f.text_field :links, value: @project.links %>
     </div>
 
     <div class="field">

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -7,7 +7,11 @@
             :id,
             :name,
             { prompt: "Please select the idea this project will work on", include_blank: true },
-            { class: "full-width", required: true }
+            {
+                class: "full-width",
+                required: true,
+                disabled: @project.persisted?
+            }
         ) %>
     </div>
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,2 +1,2 @@
-<h2>Edit Project: <%= @project.name %> for the <%= @event.time.strftime("%B %d, %Y")%> EzHackathon</h2>
+<h2>Edit Project: <%= @project.idea.name %> for the <%= format_date(@event.time) %> EzHackathon</h2>
 <%= render :partial => '/projects/form' %>

--- a/spec/features/user_creates_new_project_spec.rb
+++ b/spec/features/user_creates_new_project_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "when user creates a new project" do
+  let!(:event) { create(:event) }
+  let!(:idea) { create(:idea, name: "A great idea") }
+
+  scenario "user successfully creates new project" do
+    visit event_path(event)
+    click_button "Add a New Project"
+
+    expect(page).to have_content "Submit a New Project"
+
+    select "A great idea", from: "project[idea_id]"
+
+    click_button "Create Project"
+
+    expect(page).to have_content "Project added successfully"
+    expect(page).to have_content "A great idea"
+  end
+
+  scenario "user does not enter all required information" do
+    visit event_path(event)
+    click_button "Add a New Project"
+
+    click_button "Create Project"
+
+    expect(page).to have_content "Idea must exist"
+  end
+end

--- a/spec/features/user_edits_project_spec.rb
+++ b/spec/features/user_edits_project_spec.rb
@@ -5,13 +5,29 @@ require "rails_helper"
 feature "when user edits a project" do
   let!(:event) { create(:event, time: "2021-09-30") }
   let!(:idea) { create(:idea, name: "A great idea") }
-  let!(:project) { create(:project, event: event, idea: idea) }
 
-  scenario "user successfully creates new project" do
+  let!(:project) do
+    create(
+      :project,
+      event: event,
+      idea: idea,
+      links: "None yet!",
+      additional_comments: "N/A"
+    )
+  end
+
+  scenario "user views form for project with existing info" do
     visit edit_event_project_path(event, project)
 
     expect(page).to have_content idea.name
     expect(page).to have_content "Thursday September 30, 2021"
+    expect(page).to have_field("project[idea_id]", with: idea.id)
+    expect(page).to have_field("project[links]", with: "None yet!")
+    expect(page).to have_field("project[additional_comments]", with: "N/A")
+  end
+
+  scenario "user successfully edits new project" do
+    visit edit_event_project_path(event, project)
 
     fill_in "project[links]", with: "https://example.com/my-great-idea-writeup"
 

--- a/spec/features/user_edits_project_spec.rb
+++ b/spec/features/user_edits_project_spec.rb
@@ -21,7 +21,7 @@ feature "when user edits a project" do
 
     expect(page).to have_content idea.name
     expect(page).to have_content "Thursday September 30, 2021"
-    expect(page).to have_field("project[idea_id]", with: idea.id)
+    expect(find_field("project[idea_id]", disabled: true).value).to eq idea.id.to_s
     expect(page).to have_field("project[links]", with: "None yet!")
     expect(page).to have_field("project[additional_comments]", with: "N/A")
   end

--- a/spec/features/user_edits_project_spec.rb
+++ b/spec/features/user_edits_project_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "when user edits a project" do
+  let!(:event) { create(:event, time: "2021-09-30") }
+  let!(:idea) { create(:idea, name: "A great idea") }
+  let!(:project) { create(:project, event: event, idea: idea) }
+
+  scenario "user successfully creates new project" do
+    visit edit_event_project_path(event, project)
+
+    expect(page).to have_content idea.name
+    expect(page).to have_content "Thursday September 30, 2021"
+
+    fill_in "project[links]", with: "https://example.com/my-great-idea-writeup"
+
+    click_button "Update Project"
+
+    expect(page).to have_content "Project successfully updated"
+    expect(page).to have_content "A great idea"
+    expect(project.reload.links).to eq "https://example.com/my-great-idea-writeup"
+  end
+end

--- a/spec/features/user_visits_ideas_index_spec.rb
+++ b/spec/features/user_visits_ideas_index_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 feature "when visiting the ideas index page" do
-  let!(:idea_1) { FactoryBot.create(:idea) }
-  let!(:idea_2) { FactoryBot.create(:idea) }
+  let!(:idea_1) { create(:idea) }
+  let!(:idea_2) { create(:idea) }
 
   scenario "user sees a list of idea names and taglines" do
     visit "/ideas"

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe ProjectHelper do
+  describe "#available_ideas_for" do
+    let(:ideas_without_projects) do
+      [
+        create(:idea, name: "Idea E"),
+        create(:idea, name: "Idea B"),
+      ]
+    end
+
+    let(:ideas_with_projects) do
+      [
+        create(:project, idea: create(:idea, name: "Idea D")),
+        create(:project, idea: create(:idea, name: "Idea A")),
+      ]
+    end
+
+    context "when the project is not persisted" do
+      let(:project) { Project.new }
+
+      context "when there are just ideas without projects" do
+        before { ideas_without_projects }
+
+        it "returns those ideas, ordered by name" do
+          expect(available_ideas_for(project).map(&:name)).to match_ordered_array(
+            ["Idea B", "Idea E"]
+          )
+        end
+      end
+
+      context "when there are ideas with and without projects" do
+        before do
+          ideas_without_projects
+          ideas_with_projects
+        end
+
+        it "returns only the ideas without projects, ordered by name" do
+          expect(available_ideas_for(project).map(&:name)).to match_ordered_array(
+            ["Idea B", "Idea E"]
+          )
+        end
+      end
+    end
+
+    context "when the project is persisted" do
+      let(:project) { create(:project, idea: project_idea) }
+      let(:project_idea) { create(:idea, name: "Idea C") }
+
+      context "when there are ideas without projects" do
+        before { ideas_without_projects }
+
+        it "returns only the project's idea first, then the ideas without projects, ordered by name" do
+          expect(available_ideas_for(project).map(&:name)).to match_ordered_array(
+            ["Idea C", "Idea B", "Idea E"]
+          )
+        end
+      end
+
+      context "when there are ideas with and without projects" do
+        before do
+          ideas_without_projects
+          ideas_with_projects
+        end
+
+        it "returns only the project's idea first, then the ideas without projects, ordered by name" do
+          expect(available_ideas_for(project).map(&:name)).to match_ordered_array(
+            ["Idea C", "Idea B", "Idea E"]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe Idea do
   it { is_expected.to validate_presence_of(:value_delivered) }
   it { is_expected.to validate_presence_of(:goal) }
   it { is_expected.to validate_presence_of(:hours_estimate) }
+
+  describe ".without_projects" do
+    it "returns just the ideas that do not have projects" do
+      FactoryBot.create_list(:project, 2).map(&:idea)
+      ideas_without_projects = FactoryBot.create_list(:idea, 2)
+
+      expect(described_class.without_projects).to match_array(ideas_without_projects)
+    end
+  end
 end

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Idea do
 
   describe ".without_projects" do
     it "returns just the ideas that do not have projects" do
-      FactoryBot.create_list(:project, 2).map(&:idea)
-      ideas_without_projects = FactoryBot.create_list(:idea, 2)
+      create_list(:project, 2).map(&:idea)
+      ideas_without_projects = create_list(:idea, 2)
 
       expect(described_class.without_projects).to match_array(ideas_without_projects)
     end


### PR DESCRIPTION
## What did we change?

* Changed projects so they can be created from a dropdown of ideas
* Ensured projects can be edited
* Fixed some links to editing projects

## Why are we doing this?

We want to be able to create projects from ideas so we aren't duplicating info onto both models.

Here's a gif of this UI in action. Note: there isn't yet a `show` page for projects, so we don't yet have a place to show most of the information from the idea.

![hackathon_projects](https://user-images.githubusercontent.com/62262977/135335430-02344842-0b0b-4133-9941-4c30a5616f9c.gif)

## Checklist
- [x] Automated Tests (check all that apply)
  - [ ] Unit
  - [x] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
