### PR TITLE
Add event leaderboard, including a voting completed version.

### DIFF
--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class AwardsController < ApplicationController
+  VOTING_COMPLETE_WINNERS = 2
+
+  def index
+    @event  = event
+    @awards = awards_with_projects_ordered_by_votes
+  end
+
+  protected
+
+  def awards_with_projects_ordered_by_votes
+    Award.order(:title).each_with_object({}) do |award, rankings|
+      rankings[award] = projects_ordered_by_votes_for(award).limit(project_limit)
+    end
+  end
+
+  def event
+    @_event ||= Event.find(params[:event_id])
+  end
+
+  def project_limit
+    if voting_complete?
+      VOTING_COMPLETE_WINNERS
+    end
+  end
+
+  def projects_ordered_by_votes_for(award)
+    event.projects.
+      select("projects.*, COUNT(votes.id) AS vote_count").
+      includes(:idea).
+      joins("LEFT OUTER JOIN votes ON votes.award_id = #{award.id} AND votes.project_id = projects.id").
+      group(:id).
+      order(vote_count: :desc)
+  end
+
+  def voting_complete?
+    params[:voting_complete].present?
+  end
+  helper_method :voting_complete?
+end

--- a/app/helpers/award_helper.rb
+++ b/app/helpers/award_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AwardHelper
+  def award_place(index)
+    if index.zero?
+      "Winner"
+    elsif index == 1
+      "Runner-up"
+    end
+  end
+end

--- a/app/views/awards/index.html.erb
+++ b/app/views/awards/index.html.erb
@@ -1,0 +1,25 @@
+<h1>Awards</h1>
+
+<ul>
+  <% @awards.each do |award, projects| %>
+    <li>
+      <h2><%= award.title %><h2/>
+
+      <ol>
+        <% projects.each.with_index do |project, index| %>
+          <li>
+            <% if voting_complete? %>
+              <% if index.zero? %>
+                Winner: <%= project.idea.name %>
+              <% else %>
+                Runner-up: <%= project.idea.name %>
+              <% end %>
+            <% else %>
+              <%= project.idea.name %> (<%= pluralize project.vote_count, "vote" %>)
+            <% end %>
+          </li>
+        <% end %>
+      </ol>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/awards/index.html.erb
+++ b/app/views/awards/index.html.erb
@@ -9,13 +9,13 @@
         <% projects.each.with_index do |project, index| %>
           <li>
             <% if voting_complete? %>
-              <% if index.zero? %>
-                Winner: <%= project.idea.name %>
-              <% else %>
-                Runner-up: <%= project.idea.name %>
-              <% end %>
-            <% else %>
-              <%= project.idea.name %> (<%= pluralize project.vote_count, "vote" %>)
+              <%= award_place(index) %>:
+            <% end %>
+
+            <%= project.idea.name %>
+
+            <% unless voting_complete? %>
+              (<%= pluralize project.vote_count, "vote" %>)
             <% end %>
           </li>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Ezhackathon::Application.routes.draw do
 
   resources :ideas, except: [:destroy]
   resources :events, except: [:destroy] do
+    resources :awards, only: [:index]
     resources :projects, except: [:destroy]
   end
 end

--- a/spec/factories/votes.rb
+++ b/spec/factories/votes.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     event
     project
 
-    name { "Lil Sebastian" }
+    name { |n| "Lil Sebastian #{n}" }
   end
 end

--- a/spec/features/user_visits_event_awards_index_spec.rb
+++ b/spec/features/user_visits_event_awards_index_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "when visiting the event awards index page" do
+  let!(:event) { create(:event) }
+
+  scenario "user sees a list of awards" do
+    awards = create_list(:award, 2)
+
+    visit "/events/#{event.id}/awards"
+
+    awards.each do |award|
+      expect(page).to have_content(award.title)
+    end
+  end
+
+  scenario "user sees each project with votes" do
+    award = create(:award)
+    project_1, project_2 = create_list(:project, 2, event: event)
+    create(:vote, award: award, event: event, project: project_1)
+    create_list(:vote, 2, award: award, event: event, project: project_2)
+
+    visit "/events/#{event.id}/awards"
+
+    expect(page).to have_content("#{project_2.idea.name} (2 votes)")
+    expect(page).to have_content("#{project_1.idea.name} (1 vote)")
+  end
+
+  scenario "user sees each projects ordered by votes" do
+    award = create(:award)
+    project_1, project_2 = create_list(:project, 2, event: event)
+    create(:vote, award: award, event: event, project: project_1)
+    create_list(:vote, 2, award: award, event: event, project: project_2)
+
+    visit "/events/#{event.id}/awards"
+
+    expect(page).to have_content(/#{project_2.idea.name}.*#{project_1.idea.name}/)
+  end
+
+  scenario "user sees winner and runner up when voting is complete" do
+    award = create(:award)
+    project_1, project_2 = create_list(:project, 3, event: event)
+    create(:vote, award: award, event: event, project: project_1)
+    create_list(:vote, 2, award: award, event: event, project: project_2)
+
+    visit "/events/#{event.id}/awards?voting_complete=true"
+
+    expect(page).to have_content("Winner: #{project_2.idea.name}")
+    expect(page).to have_content("Runner-up: #{project_1.idea.name}")
+    expect(page).not_to have_content("vote")
+  end
+end


### PR DESCRIPTION
## What did we change?

- Added a leaderboard that orders projects by votes under each award.
- Added support for swapping to a results leaderboard displaying the winner and runner-up.
  - This is using a temporary query parameter to swap for now, but will use a different method later.

## Why are we doing this?

We want to use the Hackathon website for voting and results, also allowing for a history of past events.

## Checklist

- [x] Automated Tests (check all that apply)
  - [x] Unit
  - [x] Request/Integration

#### Voting in Progress

<img width="1456" alt="in-progress" src="https://user-images.githubusercontent.com/8506/135501363-8b21c3d6-f05d-4937-bbc9-3f0045ff9ce0.png">

### Voting Finalized

<img width="1456" alt="finalized" src="https://user-images.githubusercontent.com/8506/135501375-d3e2e72a-f417-49a2-ac96-7a1ddb957eb1.png">


