### PR TITLE
Update project links on event page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -55,7 +55,9 @@ body {
  }
 
  .project {
-    margin-bottom: 2em;
+    border-bottom: 3px dashed rgb(81, 190, 81);
+    margin-bottom: 1em;
+    padding-bottom: 1em;
  }
 
  .tagline {

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,10 +19,11 @@
 
   <% @projects.each do |project|%>
     <div class="project">
-      <a href=<%=project.links%>><%="#{project.idea.name}: #{project.idea.tagline}"%></a>
+      <h4><%="#{project.idea.name}: #{project.idea.tagline}"%></h4>
       <div class="tagline">
         <%=project.idea.description%>
       </div>
+      <a href=<%=project.links%>>Project Artifact</a>
       <%= link_to "Edit Project", edit_event_project_path(@event, project), :method => "get" %>
     </div>
   <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -24,7 +24,7 @@
         <%=project.idea.description%>
       </div>
       <% if project.links.present? %>
-        <a href=<%=project.links%>>Project Artifact</a>
+        <a href="<%=project.links%>">Project Artifact</a>
       <% end %>
       <%= link_to "Edit Project", edit_event_project_path(@event, project), :method => "get" %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,7 +23,9 @@
       <div class="tagline">
         <%=project.idea.description%>
       </div>
-      <a href=<%=project.links%>>Project Artifact</a>
+      <% if project.links.present? %>
+        <a href=<%=project.links%>>Project Artifact</a>
+      <% end %>
       <%= link_to "Edit Project", edit_event_project_path(@event, project), :method => "get" %>
     </div>
   <% end %>


### PR DESCRIPTION
## What did we change?
- Makes the project title just a title
- Adds a separate link for the project artifact
- Artifact link only shows if there is an artifact
- Adds a dashed green line between each project

## Why are we doing this?
Make the artifacts easy to find for each project

## Screenshot
![Projects listed on the event page with new artifact link](https://user-images.githubusercontent.com/11034063/135501547-57800da6-6728-4cca-8e5f-d9124bc796f8.png)


## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
