### PR TITLE
Enable voting on projects

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -123,3 +123,8 @@ body {
     border-color: #17a2b8;
     color: #17a2b8;
  }
+
+ input[type=radio] {
+    width: auto;
+    margin-right: 10px;
+ }

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -4,8 +4,7 @@ class VotesController < ApplicationController
   before_action :load_event
 
   def new
-    @username = params[:username]
-    @finished_voting = params[:finished_voting] || false
+    @strategy = ::Voting::UrlControlledVotingStrategy.new(params: params, event: @event)
   end
 
   private
@@ -13,14 +12,4 @@ class VotesController < ApplicationController
   def load_event
     @event = Event.find(params[:event_id])
   end
-
-  def user_started_voting?
-    @username.present?
-  end
-  helper_method :user_started_voting?
-
-  def user_finished_voting?
-    @finished_voting
-  end
-  helper_method :user_finished_voting?
 end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class VotesController < ApplicationController
+  before_action :load_event
+
+  def new
+    @username = params[:username]
+    @finished_voting = params[:finished_voting] || false
+  end
+
+  private
+
+  def load_event
+    @event = Event.find(params[:event_id])
+  end
+
+  def user_started_voting?
+    @username.present?
+  end
+  helper_method :user_started_voting?
+
+  def user_finished_voting?
+    @finished_voting
+  end
+  helper_method :user_finished_voting?
+end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -2,15 +2,34 @@
 
 class VotesController < ApplicationController
   before_action :load_event
+  before_action :load_control_strategy
+  before_action :load_state
 
-  def new
-    strategy = ::Voting::UrlControlledVotingStrategy.new(params: params)
-    @state = ::Voting::State.new(control_strategy: strategy, event: @event)
+  def new; end
+
+  def create
+    project = Project.find(params[:project_id])
+    @vote = Vote.create!(
+      award: @state.current_award,
+      project: project,
+      name: @state.username,
+      event: @event
+    )
+    flash[:success] = "Vote successfully recorded"
+    redirect_to @control_strategy.build_next_path(@state)
   end
 
   private
 
   def load_event
     @event = Event.find(params[:event_id])
+  end
+
+  def load_control_strategy
+    @control_strategy = ::Voting::UrlControlledVotingStrategy.new(params: params)
+  end
+
+  def load_state
+    @state = ::Voting::State.new(control_strategy: @control_strategy, event: @event)
   end
 end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -4,7 +4,8 @@ class VotesController < ApplicationController
   before_action :load_event
 
   def new
-    @strategy = ::Voting::UrlControlledVotingStrategy.new(params: params, event: @event)
+    strategy = ::Voting::UrlControlledVotingStrategy.new(params: params)
+    @state = ::Voting::State.new(control_strategy: strategy, event: @event)
   end
 
   private

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -4,4 +4,8 @@ module DateHelper
   def format_date(date_or_time)
     date_or_time.strftime("%A %B %d, %Y")
   end
+
+  def format_month(date_or_time)
+    date_or_time.strftime("%B %Y")
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,4 +5,8 @@ class Event < ApplicationRecord
 
   has_many :projects, dependent: :restrict_with_exception
   has_many :votes, dependent: :destroy
+
+  def voting_enabled?
+    true # Perhaps change this based on a status / stage column?
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,4 +5,6 @@ class Project < ApplicationRecord
   belongs_to :idea
 
   has_many :votes, dependent: :destroy
+
+  delegate :name, to: :idea
 end

--- a/app/services/voting/state.rb
+++ b/app/services/voting/state.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Voting
+  class State
+    attr_reader :event
+
+    def initialize(control_strategy:, event:)
+      @control_strategy = control_strategy
+      @event = event
+    end
+
+    delegate :username,
+             :user_started_voting?,
+             :user_finished_voting?,
+             :current_award_id,
+             to: :@control_strategy
+
+    def ordered_projects
+      @_ordered_projects ||= projects.order("ideas.name")
+    end
+
+    def shuffled_projects
+      projects.shuffle
+    end
+
+    def awards
+      @_awards ||= Award.order(:title)
+    end
+
+    def current_award
+      return @_current_award if defined? @_current_award
+
+      @_current_award = current_award_id.nil? ? nil : Award.find(current_award_id)
+    end
+
+    def next_award
+      return @_next_award if defined? @_next_award
+
+      @_next_award = if current_award.nil?
+        awards.first
+      elsif current_award == awards.last
+        nil
+      else
+        awards[current_award_index + 1]
+      end
+    end
+
+    def current_award_index
+      @_current_award_index ||= if current_award.nil?
+        0
+      else
+        awards.find_index { |award| award == current_award }
+      end
+    end
+
+    def submit_label
+      next_award.present? ? "Vote and move to next award" : "Vote"
+    end
+
+    private
+
+    def projects
+      event.projects.includes(:idea)
+    end
+  end
+end

--- a/app/services/voting/state.rb
+++ b/app/services/voting/state.rb
@@ -37,20 +37,20 @@ module Voting
       return @_next_award if defined? @_next_award
 
       @_next_award = if current_award.nil?
-        awards.first
-      elsif current_award == awards.last
-        nil
-      else
-        awards[current_award_index + 1]
-      end
+                       awards.first
+                     elsif current_award == awards.last
+                       nil
+                     else
+                       awards[current_award_index + 1]
+                     end
     end
 
     def current_award_index
       @_current_award_index ||= if current_award.nil?
-        0
-      else
-        awards.find_index { |award| award == current_award }
-      end
+                                  0
+                                else
+                                  awards.find_index { |award| award == current_award }
+                                end
     end
 
     def submit_label

--- a/app/services/voting/url_controlled_voting_strategy.rb
+++ b/app/services/voting/url_controlled_voting_strategy.rb
@@ -21,5 +21,20 @@ module Voting
     def current_award_id
       @params[:award_id]
     end
+
+    def build_next_path(voting_state)
+      next_params = { username: username }
+
+      if voting_state.next_award.present?
+        next_params[:award_id] = voting_state.next_award.id
+      else
+        next_params[:finished_voting] = true
+      end
+
+      Rails.application.routes.url_helpers.new_event_vote_path(
+        voting_state.event,
+        **next_params
+      )
+    end
   end
 end

--- a/app/services/voting/url_controlled_voting_strategy.rb
+++ b/app/services/voting/url_controlled_voting_strategy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Voting
+  class UrlControlledVotingStrategy
+    def initialize(params:)
+      @params = params
+    end
+
+    def username
+      @params[:username]
+    end
+
+    def user_started_voting?
+      username.present?
+    end
+
+    def user_finished_voting?
+      @params[:finished_voting] || false
+    end
+
+    def current_award_id
+      @params[:award_id]
+    end
+  end
+end

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -1,1 +1,1 @@
-<p>Hi, <%= username %>, who do you want to vote for?
+<p>Hi, <%= strategy.username %>, who do you want to vote for?

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -5,7 +5,22 @@
   <%= f.hidden_field :award_id, value: state.current_award.id %>
   <%= f.hidden_field :username, value: state.username %>
 
-  <%= f.collection_radio_buttons(:project_id, state.shuffled_projects, :id, :name) %>
+  <%= f.collection_radio_buttons(
+    :project_id,
+    state.shuffled_projects,
+    :id,
+    :name,
+    {},
+    required: true
+  ) do |b| %>
+    <div class="radio-button-wrapper">
+      <%= b.radio_button %>
+      <%= b.label %>
+      <% if b.object.links.present? %>
+        (<a href="<%= b.object.links %>" target="_blank">project artifact</a>)
+      <% end %>
+    </div>
+  <% end %>
 
-  <%= f.submit state.submit_label, name: nil %>
+  <%= f.submit state.submit_label, name: nil, id: "vote" %>
 <% end %>

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -1,1 +1,11 @@
-<p>Hi, <%= strategy.username %>, who do you want to vote for?
+<h2>"<%= state.current_award.title %>"</h2>
+<p>Award <%= state.current_award_index + 1 %> of <%= state.awards.size %></p>
+
+<%= form_with(url: "/events/#{state.event.id}/vote", local: true, method: :post) do |f| %>
+  <%= f.hidden_field :award_id, value: state.current_award.id %>
+  <%= f.hidden_field :username, value: state.username %>
+
+  <%= f.collection_radio_buttons(:project_id, state.shuffled_projects, :id, :name) %>
+
+  <%= f.submit state.submit_label, name: nil %>
+<% end %>

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -1,0 +1,1 @@
+<p>Hi, <%= username %>, who do you want to vote for?

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,7 +1,7 @@
 <h1><%= format_month(@event.time)%> Voting</h1>
 
-<% if user_started_voting? %>
-  <%= render partial: "voting", locals: { event: @event, username: @username } %>
+<% if @strategy.user_started_voting? %>
+  <%= render partial: "voting", locals: { strategy: @strategy } %>
 <% else %>
   <h2>Welcome, we hacked, now we vote!</h2>
 
@@ -10,7 +10,7 @@
   </p>
 
   <ul>
-    <% Award.all.each do |award| %>
+    <% @strategy.awards.each do |award| %>
       <li>"<%= award.title %>"</li>
     <% end %>
   </ul>
@@ -20,7 +20,7 @@
   </p>
 
   <ul>
-    <% @event.projects.includes(:idea).order("ideas.name").each do |project| %>
+    <% @strategy.projects.each do |project| %>
       <li><%= project.idea.name %></li>
     <% end %>
   </ul>

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,7 +1,11 @@
 <h1><%= format_month(@event.time)%> Voting</h1>
 
-<% if @state.user_started_voting? %>
+<% if @state.user_finished_voting? %>
+  <p>Thank you for voting!</p>
+
+<% elsif @state.user_started_voting? %>
   <%= render partial: "voting", locals: { state: @state } %>
+
 <% else %>
   <h2>Welcome, we hacked, now we vote!</h2>
 

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,7 +1,7 @@
 <h1><%= format_month(@event.time)%> Voting</h1>
 
-<% if @strategy.user_started_voting? %>
-  <%= render partial: "voting", locals: { strategy: @strategy } %>
+<% if @state.user_started_voting? %>
+  <%= render partial: "voting", locals: { state: @state } %>
 <% else %>
   <h2>Welcome, we hacked, now we vote!</h2>
 
@@ -10,7 +10,7 @@
   </p>
 
   <ul>
-    <% @strategy.awards.each do |award| %>
+    <% @state.awards.each do |award| %>
       <li>"<%= award.title %>"</li>
     <% end %>
   </ul>
@@ -20,7 +20,7 @@
   </p>
 
   <ul>
-    <% @strategy.projects.each do |project| %>
+    <% @state.ordered_projects.each do |project| %>
       <li><%= project.idea.name %></li>
     <% end %>
   </ul>
@@ -30,9 +30,10 @@
   <% if @event.voting_enabled? %>
     <p>To start voting, first enter a username.</p>
     <%= form_with(url: new_event_vote_path(@event), method: :get, local: true) do |f| %>
+      <%= f.hidden_field :award_id, value: @state.next_award.id %>
       <%= f.text_field :username, placeholder: "Username", required: true %>
 
-      <%= f.submit("Start voting!", name: nil) %>
+      <%= f.submit("Start voting!", name: nil, id: "start_voting") %>
     <% end %>
   <% else %>
     <p>Voting is not enabled at this time</p>

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,0 +1,40 @@
+<h1><%= format_month(@event.time)%> Voting</h1>
+
+<% if user_started_voting? %>
+  <%= render partial: "voting", locals: { event: @event, username: @username } %>
+<% else %>
+  <h2>Welcome, we hacked, now we vote!</h2>
+
+  <p>
+    You will be voting on the following awards:
+  </p>
+
+  <ul>
+    <% Award.all.each do |award| %>
+      <li>"<%= award.title %>"</li>
+    <% end %>
+  </ul>
+
+  <p>
+    across these projects:
+  </p>
+
+  <ul>
+    <% @event.projects.includes(:idea).order("ideas.name").each do |project| %>
+      <li><%= project.idea.name %></li>
+    <% end %>
+  </ul>
+
+  <hr/>
+
+  <% if @event.voting_enabled? %>
+    <p>To start voting, first enter a username.</p>
+    <%= form_with(url: new_event_vote_path(@event), method: :get, local: true) do |f| %>
+      <%= f.text_field :username, placeholder: "Username", required: true %>
+
+      <%= f.submit("Start voting!", name: nil) %>
+    <% end %>
+  <% else %>
+    <p>Voting is not enabled at this time</p>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Ezhackathon::Application.routes.draw do
   resources :ideas, except: [:destroy]
   resources :events, except: [:destroy] do
     resources :projects, except: [:destroy]
+    resource :vote, except: [:destroy]
   end
 end

--- a/spec/features/user_votes_on_awards_spec.rb
+++ b/spec/features/user_votes_on_awards_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "when user votes on awards for an event" do
+  let!(:event) { create(:event, time: "2021-09-30") }
+
+  let!(:awards) do
+    [
+      "Most likely to make it into production",
+      "Most likely to break production",
+    ].map { |title| create(:award, title: title) }
+  end
+
+  let!(:projects) do
+    [
+      "A useful idea",
+      "An idea that just might work",
+      "Hey, how about we convert the entire codebase to COBOL?",
+    ].map do |name|
+      create(:project, event: event, idea: create(:idea, name: name))
+    end
+  end
+
+  scenario "user starts voting" do
+    visit new_event_vote_path(event)
+    expect(page).to have_content "September 2021 Voting"
+
+    awards.each do |award|
+      expect(page).to have_content award.title
+    end
+
+    projects.each do |project|
+      expect(page).to have_content project.name
+    end
+
+    fill_in :username, with: "Test User"
+
+    click_button "start_voting"
+
+    expect(page).to have_content "Award 1 of 2"
+    projects.each do |project|
+      expect(page).to have_content project.name
+    end
+  end
+end

--- a/spec/features/user_votes_on_awards_spec.rb
+++ b/spec/features/user_votes_on_awards_spec.rb
@@ -7,8 +7,8 @@ feature "when user votes on awards for an event" do
 
   let!(:awards) do
     [
-      "Most likely to make it into production",
       "Most likely to break production",
+      "Most likely to make it into production",
     ].map { |title| create(:award, title: title) }
   end
 
@@ -17,8 +17,13 @@ feature "when user votes on awards for an event" do
       "A useful idea",
       "An idea that just might work",
       "Hey, how about we convert the entire codebase to COBOL?",
-    ].map do |name|
-      create(:project, event: event, idea: create(:idea, name: name))
+    ].map.with_index do |name, index|
+      create(
+        :project,
+        event: event,
+        links: "https://example.com/#{index}",
+        idea: create(:idea, name: name)
+      )
     end
   end
 
@@ -38,9 +43,29 @@ feature "when user votes on awards for an event" do
 
     click_button "start_voting"
 
-    expect(page).to have_content "Award 1 of 2"
     projects.each do |project|
       expect(page).to have_content project.name
+      expect(page).to have_link nil, href: project.links
     end
+  end
+
+  scenario "user votes for all awards" do
+    original_vote_count = Vote.count
+
+    visit new_event_vote_path(event)
+    fill_in :username, with: "Test User"
+    click_button "start_voting"
+
+    expect(page).to have_content "Most likely to break production"
+    expect(page).to have_content "Award 1 of 2"
+    choose "Hey, how about we convert the entire codebase to COBOL?"
+    click_button "vote"
+
+    expect(page).to have_content "Most likely to make it into production"
+    choose "An idea that just might work"
+    click_button "vote"
+
+    expect(page).to have_content "Thank you for voting!"
+    expect(Vote.count).to eq original_vote_count + 2
   end
 end


### PR DESCRIPTION
## What did we change?

Added the ability for a user to vote on all the awards at a particular event, voting for one award at a time.

This keeps the state (who's voting, where they are in the list of awards, whether they've finished voting) in URL params. This isn't particularly reliable - users could easily get around this and vote multiple times - but we can't really deal with that well until we have a `User` model and authentication.

## Why are we doing this?

So people can vote on which projects deserve awards at our current hackathon.

## What isn't included?

* Linking to voting from anywhere (we need to decide where we want this to be from)
* Editing votes (I'll probably add this next)

## Checklist
- [x] Automated Tests (check all that apply)
  - [ ] Unit
  - [x] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
