### PR TITLE
Silly answers aren't being used

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -46,6 +46,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:time, :place, :agenda, :participants, :demo_links, :silly_answers)
+    params.require(:event).permit(:time, :place, :agenda, :participants, :demo_links)
   end
 end

--- a/db/migrate/20210930172845_remove_silly_answers_from_events.rb
+++ b/db/migrate/20210930172845_remove_silly_answers_from_events.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveSillyAnswersFromEvents < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :events, :silly_answers, :text
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -67,7 +67,6 @@ CREATE TABLE public.events (
     agenda text NOT NULL,
     participants character varying NOT NULL,
     demo_links text NOT NULL,
-    silly_answers text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -367,6 +366,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210929144014'),
 ('20210929145743'),
 ('20210929151726'),
-('20210929184506');
+('20210929184506'),
+('20210930172845');
 
 


### PR DESCRIPTION
## What did we change?
Removes the reference in the controller and then removes the column from
the database.

## Why are we doing this?
This won't be used now we have the voting aspect of the hackathon

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
