### PR TITLE
Adds a gem to validate urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "turbolinks", "~> 5"
 # gem 'image_processing', '~> 1.2'
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
+gem "validate_url"
 
 group :development, :test do
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,6 +395,9 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
+    validate_url (1.0.13)
+      activemodel (>= 3.0.0)
+      public_suffix
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -457,6 +460,7 @@ DEPENDENCIES
   sprockets-rails
   tailwindcss-rails
   turbolinks (~> 5)
+  validate_url
   web-console (>= 3.3.0)
   webmock
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,5 +6,7 @@ class Project < ApplicationRecord
 
   has_many :votes, dependent: :destroy
 
+  validates :links, url: { allow_blank: true }
+
   delegate :name, to: :idea
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <div class="mt-8">
-    <%= f.label "Add any links to your final artifacts", class: "block font-bold" %>
+    <%= f.label "Add a link to your final artifact", class: "block font-bold" %>
     <%= f.text_field :links, value: @project.links %>
   </div>
 

--- a/spec/features/user_edits_project_spec.rb
+++ b/spec/features/user_edits_project_spec.rb
@@ -11,7 +11,7 @@ feature "when user edits a project" do
       :project,
       event: event,
       idea: idea,
-      links: "None yet!",
+      links: "",
       additional_comments: "N/A"
     )
   end
@@ -22,7 +22,7 @@ feature "when user edits a project" do
     expect(page).to have_content idea.name
     expect(page).to have_content "Thursday, September 30, 2021"
     expect(find_field("project[idea_id]", disabled: true).value).to eq idea.id.to_s
-    expect(page).to have_field("project[links]", with: "None yet!")
+    expect(page).to have_field("project[links]", with: "")
     expect(page).to have_field("project[additional_comments]", with: "N/A")
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Project do
+  require 'validate_url/rspec_matcher'
+
   it { is_expected.to belong_to(:event) }
   it { is_expected.to belong_to(:idea) }
 
   it { is_expected.to have_many(:votes).dependent(:destroy) }
+
+  it { is_expected.to validate_url_of(:links) }
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Project do
-  require 'validate_url/rspec_matcher'
+  require "validate_url/rspec_matcher"
 
   it { is_expected.to belong_to(:event) }
   it { is_expected.to belong_to(:idea) }


### PR DESCRIPTION
## What did we change?
Outsources validating urls

## Why are we doing this?
We want to make sure we have valid urls otherwise the link won't work

## Screenshot
![invalid url](https://user-images.githubusercontent.com/11034063/135516365-be6c79ab-1087-4062-8f3f-e2bbdb4f8306.png)

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
