### PR TITLE
Enable turning voting on and off

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,6 +50,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:time, :place, :agenda, :participants, :demo_links)
+    params.require(:event).permit(:time, :place, :agenda, :participants, :demo_links, :voting_status)
   end
 end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -4,6 +4,7 @@ class VotesController < ApplicationController
   before_action :load_event
   before_action :load_control_strategy
   before_action :load_state
+  before_action :ensure_can_vote
 
   def new; end
 
@@ -31,5 +32,12 @@ class VotesController < ApplicationController
 
   def load_state
     @state = ::Voting::State.new(control_strategy: @control_strategy, event: @event)
+  end
+
+  def ensure_can_vote
+    unless @event.voting_started? || !@state.user_started_voting?
+      flash[:notice] = "Voting is not currently enabled"
+      redirect_to new_event_vote_path(@event)
+    end
   end
 end

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module EventHelper
+  def voting_status_options(event)
+    options_for_select(
+      Event.voting_statuses.map { |name, value| [name.titleize, value] },
+      event.voting_status
+    )
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  validates :time, :place, :agenda, :participants, :demo_links, presence: true
+  validates :time, :place, :agenda, :participants, :demo_links, :voting_status, presence: true
 
   has_many :projects, dependent: :restrict_with_exception
   has_many :votes, dependent: :destroy
 
-  def voting_enabled?
-    true # Perhaps change this based on a status / stage column?
-  end
+  enum voting_status: {
+    voting_not_started: "voting_not_started",
+    voting_started: "voting_started",
+    voting_finished: "voting_finished",
+  }
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -24,6 +24,21 @@
     <%= f.text_area :demo_links %>
   </div>
 
+  <div class="mt-6">
+    <%= f.label :participants, class: "block font-bold" %>
+    <%= f.text_area :participants %>
+  </div>
+
+  <div class="mt-6">
+    <%= f.label :demo_links, class: "block font-bold" %>
+    <%= f.text_area :demo_links %>
+  </div>
+
+  <div class="mt-6">
+    <%= f.label :voting_status, class: "block font-bold" %><br />
+    <%= f.select :voting_status, voting_status_options(@event), {}, class: "full-width" %>
+  </div>
+
   <div class="mt-4 mb-8">
     <%= f.submit class: "inline-block px-5 py-3 text-base font-medium rounded-md text-white bg-ezgreen hover:bg-ezgreen-dark" %>
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,38 +20,47 @@
   <p class="mt-4">
     Voting has not yet started. However, you can get a sneaky preview of the
     awards you'll be voting on
-    <a href="<%= new_event_vote_path(@event)%>">here</a>.
+    <a href="<%= new_event_vote_path(@event)%>" class="text-ezgreen hover:underline">
+      here.
+    </a>
   </p>
 
 <% elsif @event.voting_started? %>
-  <p class="mt-4">
-    Voting is open! Cast your vote
-    <a href="<%= new_event_vote_path(@event)%>">here</a>.
+  <p class="mt-4 mb-4">
+    Voting is open!
   </p>
+  <a href="<%= new_event_vote_path(@event)%>" class="inline-block px-5 py-3 font-medium rounded-md text-white bg-ezgreen hover:bg-ezgreen-dark">
+    Cast your vote
+  </a>
 
 <% else @event.voting_started? %>
   <p class="mt-4">
     Voting has now finished for this event. You can still have a look at the
     awards and projects
-    <a href="<%= new_event_vote_path(@event)%>">here</a>.
+    <a href="<%= new_event_vote_path(@event)%>" class="text-ezgreen hover:underline">
+      here.
+    </a>
   </p>
 <% end %>
 
 <div>
   <h3 class="mt-8 text-3xl font-bold">Projects</h3>
-  <div class="mt-4">
-    <h4 class="text-2xl font-semibold">
-      <%= link_to "#{project.idea.name}: #{project.idea.tagline}", event_project_path(@event, project), class: "text-ezgreen hover:underline" %>
-    </h4>
 
-    <p>
-      <%= project.idea.description %>
-    </p>
+  <% @event.projects.each do |project|%>
+    <div class="mt-4">
+      <h4 class="text-2xl font-semibold">
+        <%= link_to "#{project.idea.name}: #{project.idea.tagline}", event_project_path(@event, project), class: "text-ezgreen hover:underline" %>
+      </h4>
 
-    <% if project.links.present? %>
-      <p><a href="<%=project.links%>" target="_blank">Project Artifact</a></p>
-    <% end %>
-  </div>
+      <p>
+        <%= project.idea.description %>
+      </p>
+
+      <% if project.links.present? %>
+        <p><a href="<%=project.links%>" target="_blank" class="text-ezgreen hover:underline">Project Artifact</a></p>
+      <% end %>
+    </div>
+  <% end %>
 </div>
 
 <div class="my-8">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -15,24 +15,43 @@
 <h3 class="mt-8 text-3xl font-bold">Demos</h3>
 <p><%= @event.demo_links %></p>
 
+<h3 class="mt-8 text-3xl font-bold">Voting</h3>
+<% if @event.voting_not_started? %>
+  <p class="mt-4">
+    Voting has not yet started. However, you can get a sneaky preview of the
+    awards you'll be voting on
+    <a href="<%= new_event_vote_path(@event)%>">here</a>.
+  </p>
+
+<% elsif @event.voting_started? %>
+  <p class="mt-4">
+    Voting is open! Cast your vote
+    <a href="<%= new_event_vote_path(@event)%>">here</a>.
+  </p>
+
+<% else @event.voting_started? %>
+  <p class="mt-4">
+    Voting has now finished for this event. You can still have a look at the
+    awards and projects
+    <a href="<%= new_event_vote_path(@event)%>">here</a>.
+  </p>
+<% end %>
+
 <div>
   <h3 class="mt-8 text-3xl font-bold">Projects</h3>
+  <div class="mt-4">
+    <h4 class="text-2xl font-semibold">
+      <%= link_to "#{project.idea.name}: #{project.idea.tagline}", event_project_path(@event, project), class: "text-ezgreen hover:underline" %>
+    </h4>
 
-  <% @event.projects.each do |project|%>
-    <div class="mt-4">
-      <h4 class="text-2xl font-semibold">
-        <%= link_to "#{project.idea.name}: #{project.idea.tagline}", event_project_path(@event, project), class: "text-ezgreen hover:underline" %>
-      </h4>
+    <p>
+      <%= project.idea.description %>
+    </p>
 
-      <p>
-        <%= project.idea.description %>
-      </p>
-
-      <% if project.links.present? %>
-        <p><a href="<%=project.links%>" target="_blank" class="text-ezgreen hover:underline">Project Artifact</a></p>
-      <% end %>
-    </div>
-  <% end %>
+    <% if project.links.present? %>
+      <p><a href="<%=project.links%>" target="_blank">Project Artifact</a></p>
+    <% end %>
+  </div>
 </div>
 
 <div class="my-8">

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -21,7 +21,9 @@
         <%= b.radio_button %>
         <%= b.label %>
         <% if b.object.links.present? %>
-          (<a href="<%= b.object.links %>" target="_blank">project artifact</a>)
+          <a href="<%= b.object.links %>" target="_blank" class="text-ezgreen hover:underline">
+            (project artifact)
+          </a>
         <% end %>
       </div>
     <% end %>

--- a/app/views/votes/_voting_overview.html.erb
+++ b/app/views/votes/_voting_overview.html.erb
@@ -1,0 +1,21 @@
+<ul class="mt-4 ml-8 list-disc leading-loose">
+  <% state.awards.each do |award| %>
+    <li>"<%= award.title %>"</li>
+  <% end %>
+</ul>
+
+<p class="mt-4">
+  across these projects:
+</p>
+
+<ul class="mt-4 ml-8 list-disc leading-loose">
+  <% state.ordered_projects.each do |project| %>
+    <li>
+      <%= project.idea.name %>
+
+      <% if project.links.present? %>
+        (<a href="<%= project.links %>" target="_blank">project artifact</a>)
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -7,33 +7,19 @@
   <%= render partial: "voting", locals: { state: @state } %>
 
 <% else %>
-  <h2 class="text-3xl font-bold">
-    Welcome, we hacked, now we vote!
-  </h2>
-
-  <p class="mt-8">
-    You will be voting on the following awards:
-  </p>
-
-  <ul class="mt-4 ml-8 list-disc leading-loose">
-    <% @state.awards.each do |award| %>
-      <li>"<%= award.title %>"</li>
-    <% end %>
-  </ul>
-
-  <p class="mt-4">
-    across these projects:
-  </p>
-
-  <ul class="mt-4 ml-8 list-disc leading-loose">
-    <% @state.ordered_projects.each do |project| %>
-      <li><%= project.idea.name %></li>
-    <% end %>
-  </ul>
-
-  <hr/>
-
   <% if @event.voting_started? %>
+    <h2 class="text-3xl font-bold">
+      Welcome, we hacked, now we vote!
+    </h2>
+
+    <p class="mt-8">
+      Voting is now open! You will be voting on the following awards:
+    </p>
+
+    <%= render partial: "voting_overview", locals: { state: @state } %>
+
+    <hr/>
+
     <p class="mt-4 mb-2">To start voting, first enter a username.</p>
     <%= form_with(url: new_event_vote_path(@event), method: :get, local: true) do |f| %>
       <%= f.hidden_field :award_id, value: @state.next_award.id %>
@@ -41,7 +27,31 @@
 
       <%= f.submit "Start voting!", name: nil, id: "start_voting", class: "block mt-4 px-5 py-3 text-base font-medium rounded-md text-white bg-ezgreen hover:bg-ezgreen-dark" %>
     <% end %>
+
+  <% elsif @event.voting_not_started? %>
+    <p class="mt-4 mb-2">
+    Voting has not yet started - please come back later!
+    </p>
+
+    <hr/>
+
+    <p class="mt-4 mb-2">
+      You will be voting on the following awards:
+    </p>
+
+    <%= render partial: "voting_overview", locals: { state: @state } %>
+
   <% else %>
-    <p class="mt-4 text-center">Voting is not enabled at this time</p>
+    <p class="mt-4 mb-2">
+    Voting is over for this event.
+    </p>
+
+    <hr/>
+
+    <p class="mt-4 mb-2">
+      Participants voted on the following awards:
+    </p>
+
+    <%= render partial: "voting_overview", locals: { state: @state } %>
   <% end %>
 <% end %>

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -31,9 +31,10 @@
     <% end %>
   </ul>
 
-  <% if @event.voting_enabled? %>
-    <p class="mt-4 mb-2">To start voting, first enter a username.</p>
+  <hr/>
 
+  <% if @event.voting_started? %>
+    <p class="mt-4 mb-2">To start voting, first enter a username.</p>
     <%= form_with(url: new_event_vote_path(@event), method: :get, local: true) do |f| %>
       <%= f.hidden_field :award_id, value: @state.next_award.id %>
       <%= f.text_field :username, placeholder: "Username", required: true %>

--- a/db/migrate/20210930181132_add_voting_status_to_event.rb
+++ b/db/migrate/20210930181132_add_voting_status_to_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVotingStatusToEvent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :voting_status, :string, null: false, default: "voting_not_started"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -68,7 +68,8 @@ CREATE TABLE public.events (
     participants character varying NOT NULL,
     demo_links text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    voting_status character varying DEFAULT 'voting_not_started'::character varying NOT NULL
 );
 
 
@@ -367,6 +368,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210929145743'),
 ('20210929151726'),
 ('20210929184506'),
-('20210930172845');
+('20210930172845'),
+('20210930181132');
 
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     agenda { "10am hacking" }
     participants { "Rachael" }
     demo_links { "Coming soon." }
+    voting_status { :voting_not_started }
   end
 end

--- a/spec/features/user_edits_event_spec.rb
+++ b/spec/features/user_edits_event_spec.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
-# require "rails_helper"
+require "rails_helper"
 
-# feature "when user edits an event" do
-#   scenario "user successfully edits an event" do
-#   end
+feature "when user edits an event" do
+  let!(:event) { create(:event) }
 
-#   scenario "user edits event with missing required info" do
-#   end
-# end
+  scenario "user successfully edits an event's voting status" do
+    visit edit_event_path(event)
+
+    select "Voting Started", from: "event[voting_status]"
+
+    click_button "Update Event"
+
+    expect(page).to have_content "Event successfully updated!"
+    expect(page).to have_content "Voting is open"
+  end
+end

--- a/spec/features/user_votes_on_awards_spec.rb
+++ b/spec/features/user_votes_on_awards_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "when user votes on awards for an event" do
-  let!(:event) { create(:event, time: "2021-09-30") }
+  let!(:event) { create(:event, time: "2021-09-30", voting_status: :voting_started) }
 
   let!(:awards) do
     [

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Event do
   it { is_expected.to validate_presence_of(:place) }
   it { is_expected.to validate_presence_of(:agenda) }
   it { is_expected.to validate_presence_of(:participants) }
+  it { is_expected.to validate_presence_of(:voting_status) }
 
   it { is_expected.to have_many(:projects) }
   it { is_expected.to have_many(:votes).dependent(:destroy) }


### PR DESCRIPTION
## What did we change?

* Added a `Event#voting_status` column - an enum with three states (not started, started, finished)
* Ensured that voting is only possible when voting is started
* Linked to the voting page from the event page

## Why are we doing this?

So that we can:

* Let people know what the awards are before the voting begins
* Turn voting on and off without deploying code

## Demo

![hackathon_voting_styled](https://user-images.githubusercontent.com/62262977/135640668-86e1235d-9380-472f-8e6e-6ab4e603197d.gif)


## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [x] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
