### PR TITLE
Add rake task to create awards

### DIFF
--- a/lib/tasks/awards.rake
+++ b/lib/tasks/awards.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :awards do
+  desc "Create our awards if they don't exist"
+  task create_awards: :environment do
+    [
+      "Most likely to trigger an alert",
+      "Most likely to make it into production",
+      "Least likely to make it into production",
+      "Best/Slickest presentation",
+      "Most outside the \"boxed lunch\"",
+      "Culture Cupcake (most aligned with ez values)",
+      "Meta Award - Most likely to WIN an award",
+      "Most Ambitious",
+    ].each do |title|
+      Award.find_or_create_by!(title: title)
+      puts "Ensured award '#{title}' exists"
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?

Added a way of creating the same awards in all environments

## Why are we doing this?

So we have a repeatable way of getting our list of awards

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
