### PR TITLE
Adds a show page for a project

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -130,3 +130,7 @@ body {
     width: auto;
     margin-right: 10px;
  }
+
+.project-artifact {
+  margin: 1em 0;
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -30,7 +30,7 @@ class ProjectsController < ApplicationController
     @event = Event.find(params[:event_id])
     if @project.update(project_params)
       flash[:success] = "Project successfully updated!"
-      redirect_to @event
+      redirect_to event_project_path
     else
       flash.now[:errors] = @project.errors.full_messages
       render :edit

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,6 +37,11 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def show
+    @project = Project.find(params[:id])
+    render :show
+  end
+
   private
 
   def project_params

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -30,7 +30,7 @@ class ProjectsController < ApplicationController
     @event = Event.find(params[:event_id])
     if @project.update(project_params)
       flash[:success] = "Project successfully updated!"
-      redirect_to event_project_path
+      redirect_to event_project_path(@event, @project)
     else
       flash.now[:errors] = @project.errors.full_messages
       render :edit

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,7 +16,7 @@
 
   <% @projects.each do |project|%>
     <div class="project">
-      <h4><%="#{project.idea.name}: #{project.idea.tagline}"%></h4>
+      <h4><%= link_to "#{project.idea.name}: #{project.idea.tagline}", event_project_path(@event, project), :method => "get" %></h4>
       <div class="tagline">
         <%=project.idea.description%>
       </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,4 @@
-<p><%= link_to "Back to Event", event_path %></p>
+<p><%= link_to "Back to Event", event_path(@project.event) %></p>
 <h1> <%=@project.name%> </h1>
 <h3> <%=@project.idea.tagline%> </h3>
 Submitted by: <%= @project.idea.submitter %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,8 +1,13 @@
 <p><%= link_to "Back to Event", event_path %></p>
-<h1> <%=@project.idea.name%> </h1>
+<h1> <%=@project.name%> </h1>
 <h3> <%=@project.idea.tagline%> </h3>
 Submitted by: <%= @project.idea.submitter %>
 
+<div class="project-artifact">
+  <% if @project.links.present? %>
+    <a href="<%=@project.links%>">Project Artifact</a>
+  <% end %>
+</div>
 <h4>Description:</h4>
 <%= @project.idea.description%>
 
@@ -20,4 +25,7 @@ Submitted by: <%= @project.idea.submitter %>
 
 <h4>How many "people hours" do you estimate it will take to plan, scope and demo?</h4>
 <%= @project.idea.hours_estimate%>
+
+<h4>Additional Comments:</h4>
+<%= @project.additional_comments %>
 <%= button_to "Edit", edit_event_project_path, :method => "get", class:"button" %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,0 +1,23 @@
+<p><%= link_to "Back to Event", event_path %></p>
+<h1> <%=@project.idea.name%> </h1>
+<h3> <%=@project.idea.tagline%> </h3>
+Submitted by: <%= @project.idea.submitter %>
+
+<h4>Description:</h4>
+<%= @project.idea.description%>
+
+<h4>What resources do you need to be successful? (a skillset, person, access to a technology etc)</h4>
+<%= @project.idea.resources%>
+
+<h4>This idea will need access to Snowflake (data):</h4>
+<%= @project.idea.snowflake_access%>
+
+<h4>What value will this idea deliver?</h4>
+<%= @project.idea.value_delivered%>
+
+<h4>What is your goal for this idea in the hackathon?</h4>
+<%= @project.idea.goal%>
+
+<h4>How many "people hours" do you estimate it will take to plan, scope and demo?</h4>
+<%= @project.idea.hours_estimate%>
+<%= button_to "Edit", edit_event_project_path, :method => "get", class:"button" %>

--- a/spec/features/user_visits_project_show_page_spec.rb
+++ b/spec/features/user_visits_project_show_page_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "when visiting a project show page" do
+  let(:idea) { create(:idea) }
+  let(:event) { create(:event) }
+
+  context "project doesn't have an artifact" do
+    let(:project) { create(:project, idea: idea, event: event, links: "") }
+
+    scenario "user sees details about a project" do
+      visit event_project_path(event, project)
+
+      expect(page).to have_content project.name
+      expect(page).to have_content project.additional_comments
+      expect(page).not_to have_content "Project Artifact"
+    end
+  end
+
+  context "project has an artifact" do
+    let(:project) { create(:project, idea: idea, event: event, links: "https://www.ezcater.com") }
+
+    scenario "user sees details about a project and a link to the artifact" do
+      visit event_project_path(event, project)
+
+      expect(page).to have_content project.name
+      expect(page).to have_content project.additional_comments
+      expect(page).to have_content "Project Artifact"
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?
Adds a show page to view information about a project.
Makes the title of each project in an event a link to the project show page.
Redirects user from edit project page back to the show page for the project rather than the event page


## Why are we doing this?
We want users to be able to view details about projects from the event page.

## Gif
![show-page-demo](https://user-images.githubusercontent.com/11034063/135531741-f0d223a6-63cc-4c59-bc18-88e70b3f730b.gif)

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
