### PR TITLE
Store usernames in cookies, not URL params

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -33,7 +33,8 @@ class VotesController < ApplicationController
   def load_control_strategy
     @control_strategy = ::Voting::CookieControlledVotingStrategy.new(
       cookies: cookies,
-      current_award_id: params[:award_id]
+      current_award_id: params[:award_id],
+      event: @event
     )
   end
 

--- a/app/services/voting/cookie_controlled_voting_strategy.rb
+++ b/app/services/voting/cookie_controlled_voting_strategy.rb
@@ -1,34 +1,35 @@
 # frozen_string_literal: true
 
 module Voting
-  class UrlControlledVotingStrategy
-    def initialize(params:)
-      @params = params
+  class CookieControlledVotingStrategy
+    attr_reader :current_award_id
+
+    def initialize(cookies:, current_award_id:)
+      @cookies = cookies
+      @current_award_id = current_award_id
+    end
+
+    def start_voting(username)
+      @cookies[:username] ||= username
     end
 
     def username
-      @params[:username]
+      @cookies[:username]
     end
 
     def user_started_voting?
       username.present?
     end
 
-    def user_finished_voting?
-      @params[:finished_voting] || false
-    end
-
-    def current_award_id
-      @params[:award_id]
+    def unfinished?
+      user_started_voting? && !user_finished_voting?
     end
 
     def build_next_path(voting_state)
-      next_params = { username: username }
+      next_params = {}
 
       if voting_state.next_award.present?
         next_params[:award_id] = voting_state.next_award.id
-      else
-        next_params[:finished_voting] = true
       end
 
       Rails.application.routes.url_helpers.new_event_vote_path(

--- a/app/services/voting/cookie_controlled_voting_strategy.rb
+++ b/app/services/voting/cookie_controlled_voting_strategy.rb
@@ -4,13 +4,15 @@ module Voting
   class CookieControlledVotingStrategy
     attr_reader :current_award_id
 
-    def initialize(cookies:, current_award_id:)
+    def initialize(cookies:, current_award_id:, event:)
       @cookies = cookies
       @current_award_id = current_award_id
+      @event = event
     end
 
     def start_voting(username)
       @cookies[:username] ||= username
+      @cookies[voting_key] = true
     end
 
     def username
@@ -18,11 +20,7 @@ module Voting
     end
 
     def user_started_voting?
-      username.present?
-    end
-
-    def unfinished?
-      user_started_voting? && !user_finished_voting?
+      username.present? && @cookies[voting_key]
     end
 
     def build_next_path(voting_state)
@@ -36,6 +34,12 @@ module Voting
         voting_state.event,
         **next_params
       )
+    end
+
+    private
+
+    def voting_key
+      "voting_on_event_#{@event.id}"
     end
   end
 end

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -3,7 +3,6 @@
 
 <%= form_with(url: event_vote_path(state.event), local: true, method: :post) do |f| %>
   <%= f.hidden_field :award_id, value: state.current_award.id %>
-  <%= f.hidden_field :username, value: state.username %>
 
   <%= f.collection_radio_buttons(
     :project_id,

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,13 +1,13 @@
 <h1><%= format_month(@event.time)%> Voting</h1>
 
-<% if @state.user_finished_voting? %>
-  <p>Thank you for voting!</p>
+<% if @event.voting_started? %>
+  <% if @state.user_finished_voting? %>
+    <p>Thank you for voting!</p>
 
-<% elsif @state.user_started_voting? %>
-  <%= render partial: "voting", locals: { state: @state } %>
+  <% elsif @state.user_started_voting? %>
+    <%= render partial: "voting", locals: { state: @state } %>
 
-<% else %>
-  <% if @event.voting_started? %>
+  <% else %>
     <h2>Welcome, we hacked, now we vote!</h2>
 
     <p>
@@ -26,26 +26,27 @@
       <%= f.submit("Start voting!", name: nil, id: "start_voting") %>
     <% end %>
 
-  <% elsif @event.voting_not_started? %>
-    <p>Voting has not yet started - please come back later!</p>
-
-    <hr/>
-
-    <p>
-      You will be voting on the following awards:
-    </p>
-
-    <%= render partial: "voting_overview", locals: { state: @state } %>
-
-  <% else %>
-    <p>Voting is over for this event.</p>
-
-    <hr/>
-
-    <p>
-      Participants voted on the following awards:
-    </p>
-
-    <%= render partial: "voting_overview", locals: { state: @state } %>
   <% end %>
+
+<% elsif @event.voting_not_started? %>
+  <p>Voting has not yet started - please come back later!</p>
+
+  <hr/>
+
+  <p>
+    You will be voting on the following awards:
+  </p>
+
+  <%= render partial: "voting_overview", locals: { state: @state } %>
+
+<% else %>
+  <p>Voting is over for this event.</p>
+
+  <hr/>
+
+  <p>
+    Participants voted on the following awards:
+  </p>
+
+  <%= render partial: "voting_overview", locals: { state: @state } %>
 <% end %>


### PR DESCRIPTION
## What did we change?

Stores the voting state in a cookie, not URL parameters

## Why are we doing this?

So it's a _little bit_ harder for users to vote multiple times, even though we don't have any auth.

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
