### PR TITLE
Open artifact links in new tab

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,7 +29,7 @@
       </p>
 
       <% if project.links.present? %>
-        <p><a href="<%=project.links%>">Project Artifact</a></p>
+        <p><a href="<%=project.links%>" target="_blank" class="text-ezgreen hover:underline">Project Artifact</a></p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -9,7 +9,7 @@
 
 <% if @project.links.present? %>
   <p class="mt-4">
-    <%= link_to "Project Artifact", @project.links, class: "text-ezgreen hover:underline" %>
+    <%= link_to "Project Artifact", @project.links, target: :_blank, class: "text-ezgreen hover:underline" %>
   </p>
 <% end %>
 


### PR DESCRIPTION
## What did we change?
Adds the `target="_blank"` parameter to the anchor tags for the project artifacts.

## Why are we doing this?
So that the links open in a new tab.

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
