### PR TITLE
Use voting status for awards and refresh when enabled.

### DIFF
--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -6,6 +6,10 @@ class AwardsController < ApplicationController
   def index
     @event  = event
     @awards = awards_with_projects_ordered_by_votes
+
+    if event.voting_started?
+      @refresh_interval = 5
+    end
   end
 
   protected

--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -21,7 +21,7 @@ class AwardsController < ApplicationController
   end
 
   def project_limit
-    if voting_complete?
+    if event.voting_finished?
       VOTING_COMPLETE_WINNERS
     end
   end
@@ -34,9 +34,4 @@ class AwardsController < ApplicationController
       group(:id).
       order(vote_count: :desc)
   end
-
-  def voting_complete?
-    params[:voting_complete].present?
-  end
-  helper_method :voting_complete?
 end

--- a/app/views/awards/index.html.erb
+++ b/app/views/awards/index.html.erb
@@ -9,14 +9,14 @@
         <% projects.each.with_index do |project, index| %>
           <li>
             <span class="font-semibold">
-              <% if voting_complete? %>
+              <% if project.event.voting_finished? %>
                 <%= award_place(index) %>:
               <% end %>
 
               <%= link_to project.idea.name, event_project_path(project.event, project), class: "text-ezgreen hover:underline" %>
             </span>
 
-            <% unless voting_complete? %>
+            <% if project.event.voting_started? %>
               (<%= pluralize project.vote_count, "vote" %>)
             <% end %>
           </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,9 @@
 <head>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <% if @refresh_interval %>
+    <meta http-equiv="refresh" content="<%= @refresh_interval %>">
+  <% end %>
 
   <title>Ezhackathon<%= content_for?(:title) ? " - #{yield(:title)}" : nil %></title>
 

--- a/spec/features/user_visits_event_awards_index_spec.rb
+++ b/spec/features/user_visits_event_awards_index_spec.rb
@@ -15,7 +15,8 @@ feature "when visiting the event awards index page" do
     end
   end
 
-  scenario "user sees each project with votes" do
+  scenario "when voting is started user sees each project with votes" do
+    event.voting_started!
     award = create(:award)
     project_1, project_2 = create_list(:project, 2, event: event)
     create(:vote, award: award, event: event, project: project_1)
@@ -27,7 +28,8 @@ feature "when visiting the event awards index page" do
     expect(page).to have_content("#{project_1.idea.name} (1 vote)")
   end
 
-  scenario "user sees each projects ordered by votes" do
+  scenario "when votiing i started user sees each projects ordered by votes" do
+    event.voting_started!
     award = create(:award)
     project_1, project_2 = create_list(:project, 2, event: event)
     create(:vote, award: award, event: event, project: project_1)
@@ -38,7 +40,8 @@ feature "when visiting the event awards index page" do
     expect(page).to have_content(/#{project_2.idea.name}.*#{project_1.idea.name}/)
   end
 
-  scenario "user sees winner and runner up when voting is complete" do
+  scenario "user sees winner and runner up when voting is finished" do
+    event.voting_finished!
     award = create(:award)
     project_1, project_2 = create_list(:project, 3, event: event)
     create(:vote, award: award, event: event, project: project_1)


### PR DESCRIPTION
## What did we change?

- Use the event voting status for award display.
- Refresh awards every 5 seconds while voting is started.

## Why are we doing this?

Lets us control how the award leaderboard is displayed and adds a rough "live" voting.