### PR TITLE
Link to awards after voting

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -38,7 +38,11 @@
     Voting has now finished for this event. You can still have a look at the
     awards and projects
     <a href="<%= new_event_vote_path(@event)%>" class="text-ezgreen hover:underline">
-      here.
+      here
+    </a>
+    and find out the
+    <a href="<%= event_awards_path(@event)%>" class="text-ezgreen hover:underline">
+      final results here!
     </a>
   </p>
 <% end %>

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,7 +1,12 @@
 <% content_for(:title) { "#{format_month(@event.time)} Voting" } %>
 
 <% if @state.user_finished_voting? %>
-  <p class="text-center">Thank you for voting!</p>
+  <p class="text-center">
+  Thank you for voting! Check out the
+    <a href="<%= event_awards_path(@event)%>" class="text-ezgreen hover:underline">
+      results so far.
+    </a>
+  </p>
 
 <% elsif @state.user_started_voting? %>
   <%= render partial: "voting", locals: { state: @state } %>

--- a/spec/features/user_votes_on_awards_spec.rb
+++ b/spec/features/user_votes_on_awards_spec.rb
@@ -69,7 +69,7 @@ feature "when user votes on awards for an event" do
     choose "An idea that just might work"
     click_button "vote"
 
-    expect(page).to have_content "Thank you for voting!"
+    expect(page).to have_content "Thank you for voting! Check out the results so far."
     expect(Vote.count).to eq original_vote_count + 2
   end
 


### PR DESCRIPTION
## What did we change?

* Linked to awards from user finished voting page
* Linked to awards from event if the voting has finished

## Why are we doing this?

So people can see who won awards

## Screenshots
---
![Screen Shot 2021-10-01 at 11 28 56 AM](https://user-images.githubusercontent.com/62262977/135646984-c9887225-1fe9-413a-90f2-f8f16f70b06a.png)
---
![Screen Shot 2021-10-01 at 11 29 27 AM](https://user-images.githubusercontent.com/62262977/135646987-db19f5c7-c00d-4bf7-94da-564233c6a7ac.png)


## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [x] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
