### PR TITLE
Enable editing votes

### DIFF
--- a/app/services/voting/state.rb
+++ b/app/services/voting/state.rb
@@ -57,6 +57,12 @@ module Voting
       next_award.present? ? "Vote and move to next award" : "Vote"
     end
 
+    def existing_vote
+      return @_existing_vote if defined? @_existing_vote
+
+      @_existing_vote = Vote.find_by(name: username, event: event, award: current_award)
+    end
+
     private
 
     def projects

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -14,7 +14,7 @@
       state.shuffled_projects,
       :id,
       :name,
-      {},
+      { checked: state.existing_vote&.project_id },
       required: true
     ) do |b| %>
       <div class="w-6/12 mx-auto text-left">

--- a/spec/features/user_votes_on_awards_spec.rb
+++ b/spec/features/user_votes_on_awards_spec.rb
@@ -92,4 +92,28 @@ feature "when user votes on awards for an event" do
     visit new_event_vote_path(event, award_id: awards.first.id, username: "cheater")
     expect(page).not_to have_selector("vote")
   end
+
+  scenario "user votes for same award twise" do
+    event.update!(voting_status: :voting_started)
+
+    original_vote_count = Vote.count
+
+    visit new_event_vote_path(event)
+    fill_in :username, with: "Test User"
+    click_button "start_voting"
+
+    expect(page).to have_content "Most likely to break production"
+    expect(page).to have_content "Award 1 of 2"
+    choose "Hey, how about we convert the entire codebase to COBOL?"
+    click_button "vote"
+
+    visit new_event_vote_path(event, username: "Test User", award_id: awards.first.id)
+
+    expect(page).to have_content "Most likely to break production"
+    choose "An idea that just might work"
+    click_button "vote"
+
+    expect(page).to have_content "Vote successfully updated"
+    expect(Vote.count).to eq original_vote_count + 1
+  end
 end


### PR DESCRIPTION
## What did we change?

Enabled editing old votes

## Why are we doing this?

So that the app doesn't break if someone hits "back" during voting, then tries to vote again.

This should _maybe_ be an `edit` and `update` action pair, but that wouldn't fix the back button issue.

## Demo

![hackathon_change_votes](https://user-images.githubusercontent.com/62262977/135650200-7943fb9a-0555-486f-bc29-a4967846fc52.gif)


## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [x] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
