### PR TITLE
Fix bug causing autorefresh after navigation

### DIFF
--- a/app/views/awards/index.html.erb
+++ b/app/views/awards/index.html.erb
@@ -25,3 +25,17 @@
     </li>
   <% end %>
 </ul>
+
+<% if @refresh_interval %>
+  <script>
+    const originalPage = location.href
+
+    document.addEventListener('turbolinks:load', function() {
+      timeoutId = setTimeout(function() {
+        if (location.href === originalPage) {
+          location.reload();
+        }
+      }, <%= @refresh_interval * 1000 %>);
+    });
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,9 +3,6 @@
 <head>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <% if @refresh_interval %>
-    <meta http-equiv="refresh" content="<%= @refresh_interval %>">
-  <% end %>
 
   <title>ezHackathons<%= content_for?(:title) ? " - #{yield(:title)}" : nil %></title>
 


### PR DESCRIPTION
## What did we change?

Implemented autorefresh of awards page in JS just on the awards page rather than in application layout.

## Why are we doing this?

When users navigated away from the awards page, the autorefresh was still happening, potentially because turbolinks doesn't replace the `<head>`. 

This uses JS and only reloads the page if it is the same URL as at the start of the timeout to make sure the user has not navigated away.  

## Checklist
- [ ] Automated Tests (check all that apply)
  - [ ] Unit
  - [ ] Request/Integration
  - [ ] Feature/System
- [ ] Migrations Reviewed (Zero Downtime https://ezcater.atlassian.net/l/c/F1u4298i)
