### PR TITLE
Support for award ties.

### DIFF
--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -16,7 +16,14 @@ class AwardsController < ApplicationController
 
   def awards_with_projects_ordered_by_votes
     Award.order(:title).each_with_object({}) do |award, rankings|
-      rankings[award] = projects_ordered_by_votes_for(award).limit(project_limit)
+      if event.voting_not_started?
+        projects = event.projects.all.group_by(&:id)
+      else
+        projects = projects_ordered_by_votes_for(award).group_by(&:vote_count)
+        projects = projects.first(project_limit) if project_limit
+      end
+
+      rankings[award] = projects
     end
   end
 

--- a/app/views/awards/index.html.erb
+++ b/app/views/awards/index.html.erb
@@ -6,18 +6,20 @@
       <h2 class="text-3xl font-bold"><%= award.title %></h2>
 
       <ol class="mt-2 ml-9 list-decimal leading-loose">
-        <% projects.each.with_index do |project, index| %>
+        <% projects.each.with_index do |(votes, project_group), index| %>
           <li>
             <span class="font-semibold">
-              <% if project.event.voting_finished? %>
+              <% if @event.voting_finished? %>
                 <%= award_place(index) %>:
               <% end %>
 
-              <%= link_to project.idea.name, event_project_path(project.event, project), class: "text-ezgreen hover:underline" %>
+              <%= project_group.map do |project| %>
+                <% link_to project.name, event_project_path(@event, project), class: "text-ezgreen hover:underline" %>
+              <% end.to_sentence.html_safe %>
             </span>
 
-            <% if project.event.voting_started? %>
-              (<%= pluralize project.vote_count, "vote" %>)
+            <% if @event.voting_started? %>
+              (<%= pluralize votes, "vote" %>)
             <% end %>
           </li>
         <% end %>

--- a/app/views/awards/index.html.erb
+++ b/app/views/awards/index.html.erb
@@ -6,14 +6,14 @@
       <h2 class="text-3xl font-bold"><%= award.title %></h2>
 
       <ol class="mt-2 ml-9 list-decimal leading-loose">
-        <% projects.each.with_index do |(votes, project_group), index| %>
+        <% projects.each.with_index do |(votes, rank_group), index| %>
           <li>
             <span class="font-semibold">
               <% if @event.voting_finished? %>
                 <%= award_place(index) %>:
               <% end %>
 
-              <%= project_group.map do |project| %>
+              <%= rank_group.map do |project| %>
                 <% link_to project.name, event_project_path(@event, project), class: "text-ezgreen hover:underline" %>
               <% end.to_sentence.html_safe %>
             </span>

--- a/spec/features/user_visits_event_awards_index_spec.rb
+++ b/spec/features/user_visits_event_awards_index_spec.rb
@@ -24,11 +24,23 @@ feature "when visiting the event awards index page" do
 
     visit "/events/#{event.id}/awards"
 
-    expect(page).to have_content("#{project_2.idea.name} (2 votes)")
-    expect(page).to have_content("#{project_1.idea.name} (1 vote)")
+    expect(page).to have_content("#{project_2.name} (2 votes)")
+    expect(page).to have_content("#{project_1.name} (1 vote)")
   end
 
-  scenario "when votiing i started user sees each projects ordered by votes" do
+  scenario "when voting is starting and projects have the same count" do
+    event.voting_started!
+    award = create(:award)
+    project_1, project_2 = create_list(:project, 2, event: event)
+    create(:vote, award: award, event: event, project: project_1)
+    create(:vote, award: award, event: event, project: project_2)
+
+    visit "/events/#{event.id}/awards"
+
+    expect(page).to have_content("#{project_1.name} and #{project_2.name} (1 vote)")
+  end
+
+  scenario "when voting is started user sees each projects ordered by votes" do
     event.voting_started!
     award = create(:award)
     project_1, project_2 = create_list(:project, 2, event: event)
@@ -37,10 +49,10 @@ feature "when visiting the event awards index page" do
 
     visit "/events/#{event.id}/awards"
 
-    expect(page).to have_content(/#{project_2.idea.name}.*#{project_1.idea.name}/)
+    expect(page).to have_content(/#{project_2.name}.*#{project_1.name}/)
   end
 
-  scenario "user sees winner and runner up when voting is finished" do
+  scenario "user sees winner and runner-up when voting is finished" do
     event.voting_finished!
     award = create(:award)
     project_1, project_2 = create_list(:project, 3, event: event)
@@ -49,8 +61,24 @@ feature "when visiting the event awards index page" do
 
     visit "/events/#{event.id}/awards?voting_complete=true"
 
-    expect(page).to have_content("Winner: #{project_2.idea.name}")
-    expect(page).to have_content("Runner-up: #{project_1.idea.name}")
+    expect(page).to have_content("Winner: #{project_2.name}")
+    expect(page).to have_content("Runner-up: #{project_1.name}")
+    expect(page).not_to have_content("vote")
+  end
+
+  scenario "user sees tied winners and runner-ups when voting is finished" do
+    event.voting_finished!
+    award = create(:award)
+    project_1, project_2, project_3, project_4 = create_list(:project, 5, event: event)
+    create_list(:vote, 2, award: award, event: event, project: project_1)
+    create_list(:vote, 2, award: award, event: event, project: project_2)
+    create(:vote, award: award, event: event, project: project_3)
+    create(:vote, award: award, event: event, project: project_4)
+
+    visit "/events/#{event.id}/awards?voting_complete=true"
+
+    expect(page).to have_content("Winner: #{project_1.name} and #{project_2.name}")
+    expect(page).to have_content("Runner-up: #{project_3.name} and #{project_4.name}")
     expect(page).not_to have_content("vote")
   end
 end


### PR DESCRIPTION
## What did we change?

- If projects have the same vote counts they'll be considered tied for their place.
- If voting is not started the project ID is treated as the vote count to keep them separate.

## Why are we doing this?

1. This fixes issues with the ordering by vote count when tied, causing the winners to change on reload.
2. It improves handling for cases where multiple projects have the same number of votes.

## Screenshots

### Not Started

<img width="1648" alt="not-started" src="https://user-images.githubusercontent.com/8506/135682505-ec2c8c78-2444-46f5-b49a-c13804e409aa.png">

### Started

<img width="1648" alt="started" src="https://user-images.githubusercontent.com/8506/135682511-66d576a7-ea6a-48f8-bda0-a93990023d8d.png">

### Finished

<img width="1648" alt="finished" src="https://user-images.githubusercontent.com/8506/135682517-034aca80-3280-4497-bc13-9d607cec98b0.png">